### PR TITLE
Fix flavored `base_url` issue

### DIFF
--- a/lib/bbmb/html/util/lookandfeel.rb
+++ b/lib/bbmb/html/util/lookandfeel.rb
@@ -196,6 +196,17 @@ La versione aggiornata delle nostre CGC può essere visionata e <a href='http://
   def navigation
     zone_navigation + super
   end
+
+  alias :orig_base_url :base_url
+
+  # Provides non flavored base url
+  def base_url
+    _flavor = @flavor
+    @flavor = nil
+    url = orig_base_url
+    @flavor = _flavor
+    url
+  end
 end
     end
   end

--- a/lib/bbmb/sandoz/version.rb
+++ b/lib/bbmb/sandoz/version.rb
@@ -1,5 +1,5 @@
 module BBMB
   module SANDOZ
-    VERSION = '1.0.0'
+    VERSION = '1.0.1'
   end
 end

--- a/test/html/util/test_lookandfeel.rb
+++ b/test/html/util/test_lookandfeel.rb
@@ -1,0 +1,31 @@
+$: << File.dirname(__FILE__)
+$: << File.expand_path('..', File.dirname(__FILE__))
+$: << File.expand_path('../../../lib', File.dirname(__FILE__))
+
+require 'minitest/autorun'
+require 'flexmock/minitest'
+require 'sbsm/session'
+require 'bbmb/html/util/lookandfeel'
+
+module BBMB
+  module Html
+    class TestApplication
+      def unknown_user; end
+    end
+
+    module Util
+      class TestLookandfeel < ::Minitest::Test
+        def setup
+          @app     = TestApplication.new
+          @session = SBSM::Session.new('test', @app)
+        end
+
+        def test_base_url_does_not_include_flavor
+          lookandfeel = Lookandfeel.new(@session)
+          assert_equal('sbsm', lookandfeel.flavor)
+          refute_match(@session.flavor, lookandfeel.base_url)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hi @zdavatz @ngiger,

This pull request fixes also same `base_url` issue on [xmlconv](https://github.com/zdavatz/xmlconv).

See also:
https://github.com/zdavatz/xmlconv/pull/1 :tada:
